### PR TITLE
Switch from deprecated np.fromstring to np.frombuffer; convert tests

### DIFF
--- a/python/pytest.ini
+++ b/python/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+python_files = test.py

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='pack64',
-    version = '2.0.0',
+    version = '2.0.1',
     maintainer='Luminoso Technologies, Inc.',
     maintainer_email='info@luminoso.com',
     url = 'http://github.com/LuminosoInsight/pack64',

--- a/python/setup.py
+++ b/python/setup.py
@@ -11,4 +11,5 @@ setup(
     description = 'A library for representing floating point vectors in a compact, base64-like format',
     py_modules=['pack64'],
     install_requires=['numpy >= 1.9.0'],
+    tests_require=['pytest']
 )


### PR DESCRIPTION
I've been getting piles of DeprecationWarnings about the fact that np.fromstring is deprecated (because it was designed for Python 2 and does weird stuff with Unicode). np.frombuffer, which operates on bytestrings, is recommended in its place.

Some things I checked:

- np.frombuffer was available in NumPy 1.9, the minimum version of NumPy we require
- The bytestring shenanigans still work on Python 2.7; I installed a minimal 2.7 env and ran the tests

I also took this opportunity to convert the tests to pytest, which was a simple matter of string replacement. The pytest requirement is indicated by the `tests_require=['pytest']` line in setup.py, which as far as I know, will continued to be ignored by all tooling, so we will need to switch this repository's test command in Jenkins.